### PR TITLE
25 Rework CLI tests to NOT depend on any drive for manipulation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,5 +19,7 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --configuration Release --no-restore
-      - name: Test
+      - name: Test EpubCore
         run: dotnet test ./EpubCore.Tests/EpubCore.Tests.csproj --no-restore --verbosity normal
+      - name: Test EpubCoreCli
+        run: dotnet test ./EpubCore.Cli.Tests/EpubCore.Cli.Tests.csproj --no-restore --verbosity normal

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,7 @@ name: build and test
 on:
   push:
     branches:
+      - feature/*
       - master
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,10 @@ jobs:
           6.0.x
     - name: Build
       run: dotnet build -c Release
-    - name: Test
+    - name: Test EpubCore
       run: dotnet test ./EpubCore.Tests/EpubCore.Tests.csproj -c Release --no-build
+    - name: Test EpubCoreCli
+      run: dotnet test ./EpubCore.Cli.Tests/EpubCore.Cli.Tests.csproj --no-restore --verbosity normal
     - name: Pack nugets
       run: dotnet pack EpubCore/EpubCore.csproj -c Release --no-build --output .
     - name: Push to NuGet

--- a/EpubCore.Cli.Tests/ActionHandlers/ActionHandlerTestBase.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/ActionHandlerTestBase.cs
@@ -13,13 +13,13 @@ public class ActionHandlerTestBase
     protected Mock<IConsoleWriter> ConsoleWriter;
     protected Mock<EpubResourceManager> ResourceRetriever;
     protected string ExecutingPath = string.Empty;
-    protected string PathToTestEpub { get; set; }
+    protected string PathToTestEpub { get; set; } = null!;
 
     protected ActionHandlerTestBase()
     {
         ConsoleWriter = new Mock<IConsoleWriter>();
         ResourceRetriever = new Mock<EpubResourceManager>();
-        ExecutingPath =Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        ExecutingPath =Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
     }
 
     public string GivenAnEpub(string epubName)

--- a/EpubCore.Cli.Tests/ActionHandlers/ActionHandlerTestBase.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/ActionHandlerTestBase.cs
@@ -1,6 +1,7 @@
 ﻿using AutoFixture;
 using EpubCore.Cli.Managers;
 using Moq;
+using System.Reflection;
 
 namespace EpubCore.Cli.Tests.ActionHandlers;
 
@@ -11,12 +12,14 @@ public class ActionHandlerTestBase
     protected Fixture Fixture = new Fixture();
     protected Mock<IConsoleWriter> ConsoleWriter;
     protected Mock<EpubResourceManager> ResourceRetriever;
+    protected string ExecutingPath = string.Empty;
     protected string PathToTestEpub { get; set; }
 
     protected ActionHandlerTestBase()
     {
         ConsoleWriter = new Mock<IConsoleWriter>();
         ResourceRetriever = new Mock<EpubResourceManager>();
+        ExecutingPath =Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
     }
 
     public string GivenAnEpub(string epubName)

--- a/EpubCore.Cli.Tests/ActionHandlers/ExtractEpubActionHandlerTests.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/ExtractEpubActionHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions.TestingHelpers;
+using System.Reflection;
 using EpubCore.Cli.ActionHandlers;
 using Moq;
 
@@ -14,11 +15,11 @@ namespace EpubCore.Cli.Tests.ActionHandlers
             PathToTestEpub = GivenAFile(TestEPub);
             
             var epubContent = await File.ReadAllBytesAsync(PathToTestEpub);
-
-            var extractPath = @$"d:\new-{Guid.NewGuid()}";
+            
+            var extractPath = @$"{ExecutingPath}/new-{Guid.NewGuid()}";
             var options = new ExtractEpubOptions()
             {
-                InputEpub = @"d:\new.epub",
+                InputEpub = @$"{ExecutingPath}/new.epub",
                 DestinationDirectory = extractPath
             };
 
@@ -27,7 +28,7 @@ namespace EpubCore.Cli.Tests.ActionHandlers
                 var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
                     { extractPath, new MockDirectoryData() },
-                    { @"d:\new.epub", new MockFileData(epubContent) }
+                    { @$"{ExecutingPath}/new.epub", new MockFileData(epubContent) }
                 });
 
                 var handler = new ExtractEPubActionHandler(fileSystem, ConsoleWriter.Object, _fileExtractor.Object);

--- a/EpubCore.Cli.Tests/ActionHandlers/GetHtmlActionHandlerTests.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/GetHtmlActionHandlerTests.cs
@@ -53,7 +53,7 @@ namespace EpubCore.Cli.Tests.ActionHandlers
 
                 if (htmlFound)
                 {
-                    ConsoleWriter.Verify(g => g.WriteSuccess(_htmlFile.TextContent), Times.Once);
+                    ConsoleWriter.Verify(g => g.WriteSuccess(_htmlFile!.TextContent), Times.Once);
                 }
                 else
                 {

--- a/EpubCore.Cli.Tests/ActionHandlers/RemoveResourceActionHandlerTests.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/RemoveResourceActionHandlerTests.cs
@@ -16,7 +16,7 @@ public class RemoveResourceActionHandlerTests : ActionHandlerTestBase
         var epubContent = File.ReadAllBytesAsync(PathToTestEpub).Result;
         _fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
         {
-            { @"d:\new.epub", new MockFileData(epubContent) }
+            { @$"{ExecutingPath}/new.epub", new MockFileData(epubContent) }
         });
     }
 
@@ -27,8 +27,8 @@ public class RemoveResourceActionHandlerTests : ActionHandlerTestBase
         {
             RemoveItemName= NameOfHtml,
             EpubResourceType = EpubResourceType.Html,
-            InputEpub = @"d:\new.epub",
-            OutputEpub = @$"d:\new-{Guid.NewGuid()}.epub"
+            InputEpub = @$"{ExecutingPath}/new.epub",
+            OutputEpub = @$"{ExecutingPath}/new-{Guid.NewGuid()}.epub"
         };
 
         try
@@ -59,8 +59,8 @@ public class RemoveResourceActionHandlerTests : ActionHandlerTestBase
         {
             RemoveItemName = NameOfCss,
             EpubResourceType = EpubResourceType.Css,
-            InputEpub = @"d:\new.epub",
-            OutputEpub = @$"d:\new-{Guid.NewGuid()}.epub"
+            InputEpub = @$"{ExecutingPath}/new.epub",
+            OutputEpub = @$"{ExecutingPath}/new-{Guid.NewGuid()}.epub"
         };
 
         try

--- a/EpubCore.Cli.Tests/ActionHandlers/ReplaceCoverActionHandlerTests.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/ReplaceCoverActionHandlerTests.cs
@@ -19,17 +19,17 @@ namespace EpubCore.Cli.Tests.ActionHandlers
 
             var options = new ReplaceCoverOptions()
             {
-                InputCoverImage = @"d:\cover.jpg",
-                InputEpub = @"d:\new.epub",
-                OutputEpub = @$"d:\new-{Guid.NewGuid()}.epub"
+                InputCoverImage = @$"{ExecutingPath}/cover.jpg",
+                InputEpub = @$"{ExecutingPath}/new.epub",
+                OutputEpub = @$"{ExecutingPath}/new-{Guid.NewGuid()}.epub"
             };
 
             try
             {
                 var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
-                    { @"d:\cover.jpg", new MockFileData(newCoverContents) },
-                    { @"d:\new.epub", new MockFileData(epubContent) }
+                    { @$"{ExecutingPath}/cover.jpg", new MockFileData(newCoverContents) },
+                    { @$"{ExecutingPath}/new.epub", new MockFileData(epubContent) }
                 });
                 
                 var handler = new ReplaceCoverActionHandler(fileSystem, ConsoleWriter.Object);

--- a/EpubCore.Cli.Tests/ActionHandlers/ReplaceHtmlActionHandlerTests.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/ReplaceHtmlActionHandlerTests.cs
@@ -20,18 +20,18 @@ namespace EpubCore.Cli.Tests.ActionHandlers
 
             var options = new ReplaceHtmlOptions()
             {
-                InputHtml= @"d:\0-new.html",
+                InputHtml=@$"{ExecutingPath}/0-new.html",
                 ReplaceHtmlName= NameOfOldHtml,
-                InputEpub = @"d:\new.epub",
-                OutputEpub = @$"d:\new-{Guid.NewGuid()}.epub"
+                InputEpub =@$"{ExecutingPath}/new.epub",
+                OutputEpub = @$"{ExecutingPath}/new-{Guid.NewGuid()}.epub"
             };
 
             try
             {
                 var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
-                    { @"d:\0-new.html", new MockFileData(inputHtmlContent) },
-                    { @"d:\new.epub", new MockFileData(epubContent) }
+                    {@$"{ExecutingPath}/0-new.html", new MockFileData(inputHtmlContent) },
+                    {@$"{ExecutingPath}/new.epub", new MockFileData(epubContent) }
                 });
                 var handler = new ReplaceHtmlActionHandler(fileSystem, ConsoleWriter.Object, ResourceRetriever.Object);
                 handler.HandleCliAction(options);

--- a/EpubCore.Cli.Tests/ActionHandlers/ReplaceStylesheetActionHandlerTests.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/ReplaceStylesheetActionHandlerTests.cs
@@ -20,18 +20,18 @@ namespace EpubCore.Cli.Tests.ActionHandlers
 
             var options = new ReplaceStylesheetOptions
             {
-                InputStylesheet = @"d:\0-new.css",
+                InputStylesheet = @$"{ExecutingPath}/0-new.css",
                 ReplaceStylesheetName = NameOfOldStylesheet,
-                InputEpub = @"d:\new.epub",
-                OutputEpub = @$"d:\new-{Guid.NewGuid()}.epub"
+                InputEpub = @$"{ExecutingPath}/new.epub",
+                OutputEpub = @$"{ExecutingPath}/new-{Guid.NewGuid()}.epub"
             };
 
             try
             {
                 var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
-                    { @"d:\0-new.css", new MockFileData(inputStylesheetContent) },
-                    { @"d:\new.epub", new MockFileData(epubContent) }
+                    { @$"{ExecutingPath}/0-new.css", new MockFileData(inputStylesheetContent) },
+                    { @$"{ExecutingPath}/new.epub", new MockFileData(epubContent) }
                 });
                 var handler = new ReplaceStylesheetActionHandler(fileSystem, ConsoleWriter.Object, ResourceRetriever.Object);
                 handler.HandleCliAction(options);

--- a/EpubCore.Cli.Tests/ActionHandlers/UpdateAuthorsActionHandlerTests.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/UpdateAuthorsActionHandlerTests.cs
@@ -18,15 +18,15 @@ namespace EpubCore.Cli.Tests.ActionHandlers
             {
                 Authors = _newAuthors,
                 ClearPrevious = true,
-                InputEpub = @"d:\new.epub",
-                OutputEpub = @$"d:\new-{Guid.NewGuid()}.epub"
+                InputEpub = @$"{ExecutingPath}/new.epub",
+                OutputEpub = @$"{ExecutingPath}/new-{Guid.NewGuid()}.epub"
             };
 
             try
             {
                 var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
-                    { @"d:\new.epub", new MockFileData(epubContent) }
+                    { @$"{ExecutingPath}/new.epub", new MockFileData(epubContent) }
                 });
                 var handler = new UpdateAuthorsActionHandler(fileSystem, ConsoleWriter.Object);
                 handler.HandleCliAction(options);
@@ -62,15 +62,15 @@ namespace EpubCore.Cli.Tests.ActionHandlers
             {
                 Authors = _newAuthors,
                 ClearPrevious = false,
-                InputEpub = @"d:\new.epub",
-                OutputEpub = @$"d:\new-{Guid.NewGuid()}.epub"
+                InputEpub = @$"{ExecutingPath}/new.epub",
+                OutputEpub = @$"{ExecutingPath}/new-{Guid.NewGuid()}.epub"
             };
 
             try
             {
                 var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
-                    { @"d:\new.epub", new MockFileData(epubContent) }
+                    { @$"{ExecutingPath}/new.epub", new MockFileData(epubContent) }
                 });
                 
                 var handler = new UpdateAuthorsActionHandler(fileSystem, ConsoleWriter.Object);

--- a/EpubCore.Cli.Tests/ActionHandlers/UpdatePublishersActionHandlerTests.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/UpdatePublishersActionHandlerTests.cs
@@ -18,15 +18,15 @@ namespace EpubCore.Cli.Tests.ActionHandlers
             {
                 Publishers = _newPublishers,
                 ClearPrevious = true,
-                InputEpub = @"d:\new.epub",
-                OutputEpub = @$"d:\new-{Guid.NewGuid()}.epub"
+                InputEpub = @$"{ExecutingPath}/new.epub",
+                OutputEpub = @$"{ExecutingPath}/new-{Guid.NewGuid()}.epub"
             };
 
             try
             {
                 var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
-                    { @"d:\new.epub", new MockFileData(epubContent) }
+                    { @$"{ExecutingPath}/new.epub", new MockFileData(epubContent) }
                 });
                 var handler = new UpdatePublishersActionHandler(fileSystem, ConsoleWriter.Object);
                 handler.HandleCliAction(options);
@@ -62,15 +62,15 @@ namespace EpubCore.Cli.Tests.ActionHandlers
             {
                 Publishers = _newPublishers,
                 ClearPrevious = false,
-                InputEpub = @"d:\new.epub",
-                OutputEpub = @$"d:\new-{Guid.NewGuid()}.epub"
+                InputEpub = @$"{ExecutingPath}/new.epub",
+                OutputEpub = @$"{ExecutingPath}/new-{Guid.NewGuid()}.epub"
             };
 
             try
             {
                 var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
-                    { @"d:\new.epub", new MockFileData(epubContent) }
+                    { @$"{ExecutingPath}/new.epub", new MockFileData(epubContent) }
                 });
                 
                 var handler = new UpdatePublishersActionHandler(fileSystem, ConsoleWriter.Object);

--- a/EpubCore.Cli.Tests/ActionHandlers/UpdateTitlesActionHandlerTests.cs
+++ b/EpubCore.Cli.Tests/ActionHandlers/UpdateTitlesActionHandlerTests.cs
@@ -16,15 +16,15 @@ namespace EpubCore.Cli.Tests.ActionHandlers
             var options = new UpdateTitlesOptions()
             {
                 Titles = newTitles,
-                InputEpub = @"d:\new.epub",
-                OutputEpub = @$"d:\new-{Guid.NewGuid()}.epub"
+                InputEpub = @$"{ExecutingPath}/new.epub",
+                OutputEpub = @$"{ExecutingPath}/new-{Guid.NewGuid()}.epub"
             };
 
             try
             {
                 var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
-                    { @"d:\new.epub", new MockFileData(epubContent) }
+                    { @$"{ExecutingPath}/new.epub", new MockFileData(epubContent) }
                 });
                 var handler = new UpdateTitlesActionHandler(fileSystem, ConsoleWriter.Object);
                 handler.HandleCliAction(options);

--- a/EpubCore.Cli/ActionHandlers/ExtractEPubActionHandler.cs
+++ b/EpubCore.Cli/ActionHandlers/ExtractEPubActionHandler.cs
@@ -16,7 +16,7 @@ public class ExtractEPubActionHandler : EpubActionHandlerBase, ICliActionHandler
         if (options is not ExtractEpubOptions extractEpubOptions) return;
         if (!RetrieveAndValidateEpubSuccessful(extractEpubOptions)) return;
 
-        if (_fileExtractor.ExtractToDirectory(extractEpubOptions.InputEpub, extractEpubOptions.DestinationDirectory))
+        if (_fileExtractor.ExtractToDirectory(extractEpubOptions.InputEpub!, extractEpubOptions.DestinationDirectory))
         {
             ConsoleWriter.WriteSuccess($"Extract to {extractEpubOptions.DestinationDirectory} complete");
         }

--- a/EpubCore.Cli/ActionHandlers/ExtractEpubOptions.cs
+++ b/EpubCore.Cli/ActionHandlers/ExtractEpubOptions.cs
@@ -5,7 +5,8 @@ namespace EpubCore.Cli.ActionHandlers;
 [Verb("extract", HelpText = "Extract the contents of this EPub file")]
 public class ExtractEpubOptions : EpubInputOptionsBase
 {
-    [Option('d', "destination", Required = true, HelpText = "path to destination directory of where to extract the EPub's files")]
-    public string DestinationDirectory { get; set; }
+    [Option('d', "destination", Required = true,
+        HelpText = "path to destination directory of where to extract the EPub's files")]
+    public string DestinationDirectory { get; set; } = string.Empty;
 
 }

--- a/EpubCore.Cli/ActionHandlers/GetEpubDetailsActionHandler.cs
+++ b/EpubCore.Cli/ActionHandlers/GetEpubDetailsActionHandler.cs
@@ -19,7 +19,7 @@ public class GetEpubDetailsActionHandler : EpubActionHandlerBase, ICliActionHand
         if (options is not GetEpubDetailsOptions getEpubDetailsOptions) return;
         if (!RetrieveAndValidateEpubSuccessful(getEpubDetailsOptions)) return;
 
-        var getEpubDetails = _getEpubDetailsFactory.Create(EpubToProcess, getEpubDetailsOptions.Filter.ToList());
+        var getEpubDetails = _getEpubDetailsFactory.Create(EpubToProcess!, getEpubDetailsOptions.Filter.ToList());
 
         switch (getEpubDetailsOptions.OutputFormat)
         {

--- a/EpubCore.Cli/ActionHandlers/GetEpubDetailsOptions.cs
+++ b/EpubCore.Cli/ActionHandlers/GetEpubDetailsOptions.cs
@@ -5,7 +5,10 @@ namespace EpubCore.Cli.ActionHandlers;
 [Verb("get-details", HelpText = "Get details about this EPub file")]
 public class GetEpubDetailsOptions : GetOptionsBase
 {
-    [Option('f', "filter", HelpText = "Pipe-delimited filter keys of the data you want to be returned.  Filter values include: Uniqueidentifier|Version|Authors|Publishers|Contributors|Titles|Toc|Css|Cover|Images|Fonts|Html", Separator = '|')]
-    public IEnumerable<GetEpubFilterKey> Filter { get; set; }
+    [Option('f', "filter",
+        HelpText =
+            "Pipe-delimited filter keys of the data you want to be returned.  Filter values include: Uniqueidentifier|Version|Authors|Publishers|Contributors|Titles|Toc|Css|Cover|Images|Fonts|Html",
+        Separator = '|')]
+    public IEnumerable<GetEpubFilterKey> Filter { get; set; } = new List<GetEpubFilterKey>();
 
 }

--- a/EpubCore.Cli/ActionHandlers/GetHtmlActionHandler.cs
+++ b/EpubCore.Cli/ActionHandlers/GetHtmlActionHandler.cs
@@ -19,7 +19,7 @@ public class GetHtmlActionHandler : EpubActionHandlerBase, ICliActionHandler
         if (options is not GetHtmlOptions getHtmlOptions) return;
         if (!RetrieveAndValidateEpubSuccessful(getHtmlOptions)) return;
 
-        var htmlFile = _epubResourceManager.RetrieveHtml(EpubToProcess, getHtmlOptions.HtmlFileName);
+        var htmlFile = _epubResourceManager.RetrieveHtml(EpubToProcess!, getHtmlOptions.HtmlFileName);
 
         if (htmlFile == null)
         {

--- a/EpubCore.Cli/ActionHandlers/GetHtmlOptions.cs
+++ b/EpubCore.Cli/ActionHandlers/GetHtmlOptions.cs
@@ -6,6 +6,6 @@ namespace EpubCore.Cli.ActionHandlers;
 public class GetHtmlOptions : EpubInputOptionsBase
 {
     [Option('h', "html-file", Required = true, HelpText = "The nme of the html file for which to fetch the contents")]
-    public string HtmlFileName { get; set; }
+    public string HtmlFileName { get; set; } = string.Empty;
 
 }

--- a/EpubCore.Cli/ActionHandlers/RemoveResourceActionHandler.cs
+++ b/EpubCore.Cli/ActionHandlers/RemoveResourceActionHandler.cs
@@ -17,7 +17,7 @@ namespace EpubCore.Cli.ActionHandlers
             if (options is not RemoveResourceOptions removeResourceOptions) return;
             if (!RetrieveAndValidateEpubSuccessful(removeResourceOptions)) return;
             
-            if (!_resourceManager.RemoveResource(EpubToProcess, EpubWriter, removeResourceOptions.RemoveItemName, removeResourceOptions.EpubResourceType))
+            if (!_resourceManager.RemoveResource(EpubToProcess!, EpubWriter!, removeResourceOptions.RemoveItemName, removeResourceOptions.EpubResourceType))
             {
                 ConsoleWriter.WriteError($"Resource file of type {removeResourceOptions.EpubResourceType} not found: {removeResourceOptions.RemoveItemName}");
                 return;

--- a/EpubCore.Cli/ActionHandlers/ReplaceCoverOptions.cs
+++ b/EpubCore.Cli/ActionHandlers/ReplaceCoverOptions.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using static System.String;
 
 namespace EpubCore.Cli.ActionHandlers;
 
@@ -6,6 +7,6 @@ namespace EpubCore.Cli.ActionHandlers;
 public class ReplaceCoverOptions : EpubManipulatorOptionsBase
 {
     [Option('c', "cover-img", Required = true, HelpText = "Path to new cover image (.jpg, .png)")]
-    public string InputCoverImage { get; set; }
+    public string InputCoverImage { get; set; } = Empty;
 
 }

--- a/EpubCore.Cli/ActionHandlers/ReplaceHtmlActionHandler.cs
+++ b/EpubCore.Cli/ActionHandlers/ReplaceHtmlActionHandler.cs
@@ -23,7 +23,7 @@ namespace EpubCore.Cli.ActionHandlers
             }
 
             var existingHtml =
-                _resourceManager.RetrieveHtml(EpubToProcess, replaceHtmlOptions.ReplaceHtmlName);
+                _resourceManager.RetrieveHtml(EpubToProcess!, replaceHtmlOptions.ReplaceHtmlName);
             if (existingHtml == null)
             {
                 ConsoleWriter.WriteError($"Existing html file not found: {replaceHtmlOptions.ReplaceHtmlName}");

--- a/EpubCore.Cli/ActionHandlers/ReplaceStylesheetActionHandler.cs
+++ b/EpubCore.Cli/ActionHandlers/ReplaceStylesheetActionHandler.cs
@@ -23,7 +23,7 @@ namespace EpubCore.Cli.ActionHandlers
             }
 
             var existingStylesheet =
-                _resourceManager.RetrieveCss(EpubToProcess, replaceCssOptions.ReplaceStylesheetName);
+                _resourceManager.RetrieveCss(EpubToProcess!, replaceCssOptions.ReplaceStylesheetName);
             if (existingStylesheet == null)
             {
                 ConsoleWriter.WriteError($"Existing css file not found: {replaceCssOptions.ReplaceStylesheetName}");

--- a/EpubCore.Cli/ActionHandlers/UpdateAuthorsActionHandler.cs
+++ b/EpubCore.Cli/ActionHandlers/UpdateAuthorsActionHandler.cs
@@ -8,19 +8,19 @@ namespace EpubCore.Cli.ActionHandlers
         {
         }
 
-        public async void HandleCliAction(object options)
+        public void HandleCliAction(object options)
         {
             if (options is not UpdateAuthorsOptions updateAuthorsOptions) return;
             if (!RetrieveAndValidateEpubSuccessful(updateAuthorsOptions)) return;
 
             if (updateAuthorsOptions.ClearPrevious)
             {
-                EpubWriter.ClearAuthors();
+                EpubWriter!.ClearAuthors();
             }
 
             foreach (var curAuthor in updateAuthorsOptions.Authors)
             {
-                EpubWriter.AddAuthor(curAuthor);
+                EpubWriter!.AddAuthor(curAuthor);
             }
             
             SaveChanges(updateAuthorsOptions);

--- a/EpubCore.Cli/ActionHandlers/UpdateAuthorsOptions.cs
+++ b/EpubCore.Cli/ActionHandlers/UpdateAuthorsOptions.cs
@@ -6,7 +6,7 @@ namespace EpubCore.Cli.ActionHandlers;
 public class UpdateAuthorsOptions : EpubManipulatorOptionsBase
 {
     [Option('a', "author", Required = true, HelpText = "Author to add to your EPub", Min=1)]
-    public IEnumerable<string> Authors { get; set; }
+    public IEnumerable<string> Authors { get; set; } = new List<string>();
 
     [Option('c', "clear-previous", HelpText = "Clear previous authors", Default = false)]
     public bool ClearPrevious { get; set; }

--- a/EpubCore.Cli/ActionHandlers/UpdatePublishersActionHandler.cs
+++ b/EpubCore.Cli/ActionHandlers/UpdatePublishersActionHandler.cs
@@ -8,19 +8,19 @@ namespace EpubCore.Cli.ActionHandlers
         {
         }
 
-        public async void HandleCliAction(object options)
+        public void HandleCliAction(object options)
         {
             if (options is not UpdatePublishersOptions updateAuthorsOptions) return;
             if (!RetrieveAndValidateEpubSuccessful(updateAuthorsOptions)) return;
 
             if (updateAuthorsOptions.ClearPrevious)
             {
-                EpubWriter.ClearPublishers();
+                EpubWriter!.ClearPublishers();
             }
 
             foreach (var curPublisher in updateAuthorsOptions.Publishers)
             {
-                EpubWriter.AddPublisher(curPublisher);
+                EpubWriter!.AddPublisher(curPublisher);
             }
             
             SaveChanges(updateAuthorsOptions);

--- a/EpubCore.Cli/ActionHandlers/UpdatePublishersOptions.cs
+++ b/EpubCore.Cli/ActionHandlers/UpdatePublishersOptions.cs
@@ -6,7 +6,7 @@ namespace EpubCore.Cli.ActionHandlers;
 public class UpdatePublishersOptions : EpubManipulatorOptionsBase
 {
     [Option('p', "publisher", Required = true, HelpText = "Publisher to add to your EPub", Min=1)]
-    public IEnumerable<string> Publishers { get; set; }
+    public IEnumerable<string> Publishers { get; set; } = new List<string>();
 
     [Option('c', "clear-previous", HelpText = "Clear previous publisher", Default = false)]
     public bool ClearPrevious { get; set; }

--- a/EpubCore.Cli/ActionHandlers/UpdateTitlesActionHandler.cs
+++ b/EpubCore.Cli/ActionHandlers/UpdateTitlesActionHandler.cs
@@ -8,12 +8,12 @@ namespace EpubCore.Cli.ActionHandlers
         {
         }
 
-        public async void HandleCliAction(object options)
+        public void HandleCliAction(object options)
         {
             if (options is not UpdateTitlesOptions updateTitlesOptions) return;
             if (!RetrieveAndValidateEpubSuccessful(updateTitlesOptions)) return;
 
-            EpubWriter.SetTitles(updateTitlesOptions.Titles);
+            EpubWriter!.SetTitles(updateTitlesOptions.Titles);
 
             SaveChanges(updateTitlesOptions);
         }

--- a/EpubCore.Cli/ActionHandlers/UpdateTitlesOptions.cs
+++ b/EpubCore.Cli/ActionHandlers/UpdateTitlesOptions.cs
@@ -6,6 +6,6 @@ namespace EpubCore.Cli.ActionHandlers;
 public class UpdateTitlesOptions : EpubManipulatorOptionsBase
 {
     [Option('t', "titles", Required = true, HelpText = "Titles to swap out of our EPub", Min=1)]
-    public IEnumerable<string> Titles { get; set; }
+    public IEnumerable<string> Titles { get; set; } = new List<string>();
 
 }

--- a/EpubCore.Cli/CommandHandler.cs
+++ b/EpubCore.Cli/CommandHandler.cs
@@ -37,7 +37,7 @@ public class CommandHandler : ICommandHandler
     private void Run(object obj)
     {
         var handler = _cliActionHandlerResolver.Resolve(obj);
-        handler.HandleCliAction(obj);
+        handler!.HandleCliAction(obj);
        
     }
 

--- a/EpubCore.Cli/Program.cs
+++ b/EpubCore.Cli/Program.cs
@@ -11,7 +11,7 @@ namespace EpubCore.Cli
         {
             using var host = CreateHostBuilder(args).Build();
 
-            var result = host.Services.GetService<ICommandHandler>()
+            var result = host.Services.GetService<ICommandHandler>()!
                 .ExecuteAsync(args).Result;
 
           


### PR DESCRIPTION
## What this change is about

Fixing up tests and cleaning up warnings

## GitHub Issue

#25


## What I've changed

* Fixed up cli tests to use app directory for saving / retrieving files
* Added build and test gh action to feature branches
* Cleaning up lots of warnings from the solution