### PR TITLE
27 Skip duplicates on push to nuget

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Pack EpubCore CLI
       run: dotnet pack EpubCore.Cli/EpubCore.Cli.csproj -c Release --no-build --output ./nupkg
     - name: Push to NuGet
-      run: dotnet nuget push "./nupkg/*.nupkg" --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "./nupkg/*.nupkg" --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## What this change is about

skip duplicates flag on push to nuget

## GitHub Issue
#27


## What I've changed

* Updated deploy gh workflow to skip duplicate nuget files when pushed