### PR TITLE
Add the option to set the Opf document language from the Epub builder

### DIFF
--- a/EpubCore.Tests/EpubWriterTests.cs
+++ b/EpubCore.Tests/EpubWriterTests.cs
@@ -123,6 +123,19 @@ namespace EpubCore.Tests
 
             writer.RemoveTitle();
         }
+        
+        [Fact]
+        public void AddLanguageTest()
+        {
+            var writer = new EpubWriter();
+            var language = "en-US";
+
+            writer.AddLanguage(language);
+
+            var epub = WriteAndRead(writer);
+            Assert.NotEmpty(epub.Format.Opf.Metadata.Languages);
+            Assert.Contains(epub.Format.Opf.Metadata.Languages, l => l.Equals(language));
+        }
 
         [Fact]
         public void SetCoverTest()

--- a/EpubCore.Tests/FluentTests/EpubBookBuilderTests.cs
+++ b/EpubCore.Tests/FluentTests/EpubBookBuilderTests.cs
@@ -219,6 +219,22 @@ public class EpubBookBuilderTests
         Assert.Equal(imageFound.Content, fileBytes);
     }
 
+    [Fact]
+    public void CanBuildWithLanguage()
+    {
+        var builder = EpubBookBuilder.Create();
+        var stream = new MemoryStream();
+        var language = "en-US";
+        builder.WithLanguage(language)
+          .Build(stream);
+
+        var epub = EpubReader.Read(stream, false);
+
+        Assert.NotNull(epub);
+        Assert.Equal(1, epub.Format.Opf.Metadata.Languages.Count);
+        Assert.Equal(epub.Format.Opf.Metadata.Languages.First(), language);
+    }
+
     private static byte[] GetFileBytes(string relativeApplicationPath)
     {
         var pathToFile = $"{AppContext.BaseDirectory}/{relativeApplicationPath}";

--- a/EpubCore/EpubWriter.cs
+++ b/EpubCore/EpubWriter.cs
@@ -295,6 +295,11 @@ namespace EpubCore
             _format.Opf.Metadata.Titles.Add(title);
         }
 
+        public void AddLanguage(string language)
+        {
+            _format.Opf.Metadata.Languages.Add(language);
+        }
+
         public void SetVersion(EpubVersion version)
         {
             _format.Opf.EpubVersion = version;

--- a/EpubCore/Fluent/EpubBookBuilder.cs
+++ b/EpubCore/Fluent/EpubBookBuilder.cs
@@ -31,7 +31,13 @@ namespace EpubCore.Fluent
             return this;
         }
 
-        public IEpubBookBuilder AddAuthor(string authorName)
+        public IEpubBookBuilder WithLanguage(string language)
+        {
+            _writer.AddLanguage(language);
+            return this;
+        }
+
+    public IEpubBookBuilder AddAuthor(string authorName)
         {
             _writer.AddAuthor(authorName);
             return this;

--- a/EpubCore/Fluent/IEpubBookBuilder.cs
+++ b/EpubCore/Fluent/IEpubBookBuilder.cs
@@ -12,6 +12,7 @@ namespace EpubCore.Fluent
         IEpubBookBuilder WithVersion(EpubVersion version);
         IEpubBookBuilder WithUniqueIdentifier(string uniqueIdentifier);
         IEpubBookBuilder WithTitle(string title);
+        IEpubBookBuilder WithLanguage(string language);
         IEpubBookBuilder AddAuthor(string authorName);
 
         IEpubBookBuilder AddAuthors(List<string> authorNames);

--- a/EpubCore/IEpubWriter.cs
+++ b/EpubCore/IEpubWriter.cs
@@ -22,6 +22,7 @@ namespace EpubCore
         void RemoveAuthor(string author);
         void RemoveTitle();
         void SetTitle(string title);
+        void AddLanguage(string language);
 
         void SetVersion(EpubVersion version);
         void SetUniqueIdentifier(string uniqueIdentifier);


### PR DESCRIPTION
## What this change is about

Add a method to the EpubBuilder to set the Language of the underlying Opf document.

## GitHub Issue

## What I've changed

* Add the method "AddLanguage" to the EpubWriter class to add the language to the OpfDocument language metadata list.
* Add the method "WithLanguage" to the EpubBuilder interface to set the OpfDocument language by calling the EpubWriter's "AddLanguage" method.
* Unit tests for the new functionality of the EpubWriter and EpubBuilder classes.