### PR TITLE
Better handling of chapter generation

### DIFF
--- a/EpubCore.Cli/EpubCore.Cli.csproj
+++ b/EpubCore.Cli/EpubCore.Cli.csproj
@@ -10,10 +10,10 @@
 	  <PackageOutputPath>../nupkg</PackageOutputPath>
 	  <Title>EpubCore.Cli</Title>
 	  <Description>EpubCore Cli</Description>
-	  <Copyright>Copyright 2023</Copyright>
+	  <Copyright>Copyright 2025</Copyright>
 	  <PackageProjectUrl>https://github.com/domingoladron/EpubCore</PackageProjectUrl>
 	  <RepositoryUrl>https://github.com/domingoladron/EpubCore</RepositoryUrl>
-	  <Version>0.9.2.0</Version>
+	  <Version>0.9.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EpubCore/EpubCore.csproj
+++ b/EpubCore/EpubCore.csproj
@@ -7,16 +7,16 @@
     <Authors>Chris Laine (domingoladron)</Authors>
     <PackageTags>epub epubs book books 2.0 3.0 3.1</PackageTags>
     <PackageId>EpubCore</PackageId>
-    <Version>1.6.1.0</Version>
+    <Version>1.6.2.0</Version>
     <Description>A library for reading and writing EPUB files.</Description>
     <PackageProjectUrl>https://github.com/domingoladron/EpubCore</PackageProjectUrl>
-    <Copyright>Copyright 2023</Copyright>
-    <AssemblyVersion>1.6.1.0</AssemblyVersion>
-    <FileVersion>1.6.1.0</FileVersion>
+    <Copyright>Copyright 2025</Copyright>
+    <AssemblyVersion>1.6.2.0</AssemblyVersion>
+    <FileVersion>1.6.2.0</FileVersion>
     <RepositoryUrl>https://github.com/domingoladron/EpubCore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Adding logic to handle x-application font mime types</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixing bug where too many Epub.Chapters generated</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
 	  <Summary></Summary>

--- a/EpubCore/EpubReader.cs
+++ b/EpubCore/EpubReader.cs
@@ -169,7 +169,12 @@ namespace EpubCore
                     {
                         chapter.SubChapters = LoadChaptersFromNav(navAbsolutePath, li, bookResources, chapter);
                     }
-                    result.Add(chapter);
+
+                    // If we don't already have a chapter with this absolute path, then add it.  Otherwise, ignore it.
+                    if (result.FirstOrDefault(x => x.AbsolutePath.Equals(chapter.AbsolutePath)) == null)
+                    {
+                        result.Add(chapter);
+                    }
 
                     previous = chapter.SubChapters.Any() ? chapter.SubChapters.Last() : chapter;
                 }


### PR DESCRIPTION
## What this change is about

If an EPub TOC contained many chapters, but all of them use the same html file with an anchor href on it (as in `my-content-page.html##some-anchor-name`, we were getting way too many Epub.Chapter referrences.

Instead, we check if the absolute path of the chapter (`my-content-page.html`) has already been added to the final list of chapters, and if so, ignore any others added.


## GitHub Issue



## What I've changed

* List changes